### PR TITLE
Fixed single quotes in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jquery-sliderbutton",
-	"description": 'jQuery UI/Mobile plugin providing a slider-based button ("slide to activate")',
+	"description": "jQuery UI/Mobile plugin providing a slider-based button (\"slide to activate\")",
 	"version": "2.0.2",
 	"keywords": ["slide", "slider", "ui", "mobile", "button"],
 	"author": {
@@ -9,7 +9,8 @@
 		"url": "https://github.com/j-ulrich"
 	},
 	"contributors": [
-		"Jimmi Agerskov <agerskovj@gmail.com>"
+		"Jimmi Agerskov <agerskovj@gmail.com>",
+		"Moses Holmström <thykka+nospam@gmail.com>"
 	],
 	"bugs": "https://github.com/j-ulrich/jquery-sliderbutton/issues",
 	"licenses": [
@@ -25,9 +26,6 @@
 	"dependencies": {
 		"jquery": ">=1.7.0 <3.0.0"
 	},
-
-	
-	
 	"homepage": "https://github.com/j-ulrich/jquery-sliderbutton",
 	"scripts": {
 		"test": "grunt qunit"


### PR DESCRIPTION
The package.json was malformed. Changing single quoted values to double quoted values – as per JSON specification – allows the package to be installed via npm.

Verify this pull request by attempting to install jquery-sliderbutton;

    $ npm install --save git+https://github.com/j-ulrich/jquery-sliderbutton.git
    npm ERR! code ENOPACKAGEJSON
    npm ERR! package.json Non-registry package missing package.json: git+https://github.com/j-ulrich/jquery-sliderbutton.git.


...then try installing the fixed fork;


    $ npm install --save git+https://github.com/thykka/jquery-sliderbutton.git
    + jquery-sliderbutton@2.0.2
    added 2 packages in 5.273s